### PR TITLE
Configure Mockito agent

### DIFF
--- a/jgpio/pom.xml
+++ b/jgpio/pom.xml
@@ -152,8 +152,22 @@
       <!-- tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.1</version>
+        <configuration>
+          <argLine>--enable-native-access=eu.softpol.lib.jgpio -javaagent:${org.mockito:mockito-core:jar}</argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Explicitly configure the Mockito agent as described [here](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3)
- add `--enable-native-access` arg to the surefire plugin