### PR TITLE
Code cleanup

### DIFF
--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/Jgpio.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/Jgpio.java
@@ -62,7 +62,7 @@ public interface Jgpio {
   /// Retrieves the version of the libgpiod library.
   ///
   /// @return a string representing the version
-  public @Nullable String version();
+  @Nullable String version();
 
   /// Provides the default implementation of the {@link Jgpio} interface.
   ///

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/Line.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/Line.java
@@ -30,13 +30,13 @@ public interface Line {
   /// Retrieves the name of the GPIO line.
   ///
   /// @return the name of the GPIO line, or null if the line has no name
-  public @Nullable String name();
+  @Nullable String name();
 
   /// Retrieves the consumer of the GPIO line.
   ///
   /// @return the name of the consumer using the line, or null if the line is not being used or if
   ///  the consumer is not defined
-  public @Nullable String consumer();
+  @Nullable String consumer();
 
   /// Retrieves the current direction of the GPIO line.
   ///

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod/GpiodChip.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod/GpiodChip.java
@@ -39,7 +39,6 @@ public class GpiodChip implements Chip {
 
   private boolean closed = false;
 
-  @SuppressWarnings("java:S117")
   private GpiodChip(MemorySegment chipPtr) {
     this.chipPtr = chipPtr;
   }


### PR DESCRIPTION
`public @Nullable ...` was used in the interfaces because the code formatter misinterpreted the `TYPE_USE` annotation