### PR TITLE
Unify args null checks

### DIFF
--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/Line.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/Line.java
@@ -15,6 +15,8 @@
  */
 package eu.softpol.lib.jgpio;
 
+import static eu.softpol.lib.jgpio.internal.ArgCheck.checkNonNull;
+
 import org.jspecify.annotations.Nullable;
 
 /// Interface representing a GPIO line.
@@ -60,6 +62,7 @@ public interface Line {
   /// @param bias the desired input line bias
   /// @return the session for the input line, which must be closed after use
   default LineInputSession openAsInput(Bias bias) {
+    checkNonNull(bias, "bias");
     return openAsInput(InputMode.builder().bias(bias).build());
   }
 
@@ -81,6 +84,7 @@ public interface Line {
   /// @param driveMode the drive mode to be set for the GPIO line
   /// @return the session for the output line, which must be closed after use
   default LineOutputSession openAsOutput(DriveMode driveMode) {
+    checkNonNull(driveMode, "driveMode");
     return openAsOutput(OutputMode.builder().driveMode(driveMode).build());
   }
 

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/ArgCheck.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/ArgCheck.java
@@ -30,7 +30,7 @@ public class ArgCheck {
 
   public static void checkNonNull(@Nullable Object obj, String argName) {
     if (obj == null) {
-      throw new IllegalArgumentException("Argument '%s' must not be null".formatted(argName));
+      throw new NullPointerException("Argument '%s' must not be null".formatted(argName));
     }
   }
 }

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/InputModeImpl.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/InputModeImpl.java
@@ -15,6 +15,8 @@
  */
 package eu.softpol.lib.jgpio.internal;
 
+import static eu.softpol.lib.jgpio.internal.ArgCheck.checkNonNull;
+
 import eu.softpol.lib.jgpio.Bias;
 import eu.softpol.lib.jgpio.InputMode;
 import org.jspecify.annotations.Nullable;
@@ -47,7 +49,7 @@ public record InputModeImpl(
 
     @Override
     public Builder consumer(String consumer) {
-      ArgCheck.checkNonNull(consumer, "consumer");
+      checkNonNull(consumer, "consumer");
       this.consumer = consumer;
       return this;
     }
@@ -60,7 +62,7 @@ public record InputModeImpl(
 
     @Override
     public Builder bias(Bias bias) {
-      ArgCheck.checkNonNull(bias, "bias");
+      checkNonNull(bias, "bias");
       this.bias = bias;
       return this;
     }

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/OutputModeImpl.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/OutputModeImpl.java
@@ -15,6 +15,8 @@
  */
 package eu.softpol.lib.jgpio.internal;
 
+import static eu.softpol.lib.jgpio.internal.ArgCheck.checkNonNull;
+
 import eu.softpol.lib.jgpio.DriveMode;
 import eu.softpol.lib.jgpio.OutputMode;
 import org.jspecify.annotations.Nullable;
@@ -51,7 +53,7 @@ public record OutputModeImpl(
 
     @Override
     public Builder consumer(String consumer) {
-      ArgCheck.checkNonNull(consumer, "consumer");
+      checkNonNull(consumer, "consumer");
       this.consumer = consumer;
       return this;
     }
@@ -64,7 +66,7 @@ public record OutputModeImpl(
 
     @Override
     public Builder driveMode(DriveMode driveMode) {
-      ArgCheck.checkNonNull(driveMode, "driveMode");
+      checkNonNull(driveMode, "driveMode");
       this.driveMode = driveMode;
       return this;
     }

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod/GpiodChip.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod/GpiodChip.java
@@ -109,8 +109,8 @@ public class GpiodChip implements Chip {
 
   @Override
   public Optional<Line> findLine(int offset) {
-    throwWhenChipClosed();
     checkNonNegative(offset, "offset");
+    throwWhenChipClosed();
     var linePtr = gpiod_h.gpiod_chip_get_line(chipPtr, offset);
     if (isNull(linePtr)) {
       return Optional.empty();
@@ -120,8 +120,8 @@ public class GpiodChip implements Chip {
 
   @Override
   public Optional<Line> findLine(String name) {
-    throwWhenChipClosed();
     checkNonNull(name, "name");
+    throwWhenChipClosed();
     try (var arena = Arena.ofConfined()) {
       var namePtr = arena.allocateFrom(name, StandardCharsets.US_ASCII);
       var linePtr = gpiod_h.gpiod_chip_find_line(chipPtr, namePtr);

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod/GpiodLine.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod/GpiodLine.java
@@ -85,15 +85,15 @@ public class GpiodLine implements Line {
 
   @Override
   public LineInputSession openAsInput(InputMode inputMode) {
-    throwWhenChipClosed();
     checkNonNull(inputMode, "inputMode");
+    throwWhenChipClosed();
     return new GpiodLineInputSession(chip, linePtr, inputMode);
   }
 
   @Override
   public LineOutputSession openAsOutput(OutputMode outputMode) {
-    throwWhenChipClosed();
     checkNonNull(outputMode, "outputMode");
+    throwWhenChipClosed();
     return new GpiodLineOutputSession(chip, linePtr, outputMode);
   }
 

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod2/Gpiod2Chip.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod2/Gpiod2Chip.java
@@ -86,8 +86,8 @@ public class Gpiod2Chip implements Chip {
 
   @Override
   public Optional<Line> findLine(int offset) {
-    throwWhenChipClosed();
     checkNonNegative(offset, "offset");
+    throwWhenChipClosed();
     if (offset >= countLines()) {
       return Optional.empty();
     }
@@ -96,8 +96,8 @@ public class Gpiod2Chip implements Chip {
 
   @Override
   public Optional<Line> findLine(String name) {
-    throwWhenChipClosed();
     checkNonNull(name, "name");
+    throwWhenChipClosed();
     try (var arena = Arena.ofConfined()) {
       var namePtr = arena.allocateFrom(name, StandardCharsets.US_ASCII);
       var offset = gpiod_h.gpiod_chip_get_line_offset_from_name(chipPtr, namePtr);

--- a/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod2/Gpiod2Line.java
+++ b/jgpio/src/main/java/eu/softpol/lib/jgpio/internal/gpiod2/Gpiod2Line.java
@@ -86,15 +86,15 @@ public class Gpiod2Line implements Line {
 
   @Override
   public LineInputSession openAsInput(InputMode inputMode) {
-    throwWhenChipClosed();
     checkNonNull(inputMode, "inputMode");
+    throwWhenChipClosed();
     return new Gpiod2LineInputSession(chip, offset, inputMode);
   }
 
   @Override
   public LineOutputSession openAsOutput(OutputMode outputMode) {
-    throwWhenChipClosed();
     checkNonNull(outputMode, "outputMode");
+    throwWhenChipClosed();
     return new Gpiod2LineOutputSession(chip, offset, outputMode);
   }
 

--- a/jgpio/src/test/java/eu/softpol/lib/jgpio/internal/ArgCheckTest.java
+++ b/jgpio/src/test/java/eu/softpol/lib/jgpio/internal/ArgCheckTest.java
@@ -55,7 +55,7 @@ class ArgCheckTest {
 
     // WHEN-THEN
     assertThatThrownBy(() -> ArgCheck.checkNonNull(value, argName))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(NullPointerException.class)
         .hasMessageContaining(argName);
   }
 


### PR DESCRIPTION
* An unexpected `null` value in the arguments throws a NullPointerException (like in Kotlin)
* The method checks for null arguments first (also like in Kotlin)